### PR TITLE
Add handler for a file change.

### DIFF
--- a/TorrentFlow/DirectoryWatcher.cs
+++ b/TorrentFlow/DirectoryWatcher.cs
@@ -6,12 +6,14 @@ namespace TorrentFlow
     class DirectoryWatcher
     {
         private readonly FileSystemWatcher watcher;
-        public DirectoryWatcher(string watchDirectory, Action<object, FileSystemEventArgs> createdHandler, NotifyFilters notifyFilters)
+        public DirectoryWatcher(string watchDirectory, Action<object, FileSystemEventArgs> handler, NotifyFilters notifyFilters)
         {
             if (Directory.Exists(watchDirectory)){
                 watcher = new FileSystemWatcher(watchDirectory);
                 watcher.NotifyFilter = notifyFilters;
-                watcher.Created += new FileSystemEventHandler(createdHandler);
+                watcher.Created += new FileSystemEventHandler(handler);
+                watcher.Changed += new FileSystemEventHandler(handler);
+
             } else
             {
                 throw new Exception("Directory does not exist!");

--- a/TorrentFlow/TorrentFlow.cs
+++ b/TorrentFlow/TorrentFlow.cs
@@ -33,7 +33,7 @@ namespace TorrentFlow
             ftp = new FTPClient(Properties.Settings.Default.FTPAddress, Properties.Settings.Default.FTPUsername, StringCipher.Decrypt(Properties.Settings.Default.FTPPassword, "TorrentFlow"));
 
             if (!Utilites.IsNullOrEmpty(Properties.Settings.Default.WatchDirectory)){
-                watcher = new DirectoryWatcher(Properties.Settings.Default.WatchDirectory, NewTorrentFileDetected, NotifyFilters.FileName | NotifyFilters.LastWrite);
+                watcher = new DirectoryWatcher(Properties.Settings.Default.WatchDirectory, NewTorrentFileDetected, NotifyFilters.LastWrite);
                 watcher.SetFilter("*.torrent");
                 watcher.Start();
             } else {


### PR DESCRIPTION
Resolves #9.

DirectoryWatcher uses `handler` for both the created and changed events.